### PR TITLE
Builder objects

### DIFF
--- a/lib/json/schema_builder/array.rb
+++ b/lib/json/schema_builder/array.rb
@@ -13,6 +13,7 @@ module JSON
         opts = args.extract_options!
         schema[:items] = args.first
         schema[:items] ||= items_entity(opts, &block).as_json
+        parent.reinitialize if parent
       end
 
       protected

--- a/lib/json/schema_builder/attribute.rb
+++ b/lib/json/schema_builder/attribute.rb
@@ -7,11 +7,14 @@ module JSON
         def attribute(name, as: nil, array: false)
           attr = as || snakeize(name)
           define_method name do |*values|
-            if array
+            result = if array
               _array_attr attr, values.flatten
             else
               _attr attr, values.first
             end
+
+            parent.reinitialize if parent
+            result
           end
           alias_method "#{ name }=", name
         end

--- a/lib/json/schema_builder/dsl.rb
+++ b/lib/json/schema_builder/dsl.rb
@@ -8,7 +8,9 @@ module JSON
         opts = args.extract_options!
         klass, name = klass_and_name_from args
         set_context_for opts
-        klass.new name, opts, &block
+        klass.new(name, opts, &block).tap do
+          reinitialize if is_a?(Entity)
+        end
       end
 
       protected

--- a/lib/json/schema_builder/entity.rb
+++ b/lib/json/schema_builder/entity.rb
@@ -54,6 +54,13 @@ module JSON
       def reinitialize
       end
 
+      def extend(child_name, &block)
+        children.find { |c| c.name == child_name.to_sym }.tap do |child|
+          raise "Property #{child_name} does not exist" unless child
+          child.eval_block(&block) if block_given?
+        end
+      end
+
       def add_fragment(child)
         @fragments[child.fragment] << child
         parent.add_fragment(child) if @parent

--- a/lib/json/schema_builder/entity.rb
+++ b/lib/json/schema_builder/entity.rb
@@ -44,6 +44,14 @@ module JSON
         initialize_with opts
         eval_block &block
         extract_types
+        @initialized = true
+      end
+
+      def initialized?
+        !!@initialized
+      end
+
+      def reinitialize
       end
 
       def add_fragment(child)

--- a/lib/json/schema_builder/object.rb
+++ b/lib/json/schema_builder/object.rb
@@ -30,6 +30,11 @@ module JSON
         super
       end
 
+      def reinitialize
+        return unless initialized?
+        extract_types
+      end
+
       def required(*values)
         case values
         when []

--- a/spec/integration/builder_initialization_spec.rb
+++ b/spec/integration/builder_initialization_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe Examples::BuilderInitialization, type: :integration do
+  it_behaves_like 'a builder' do
+    let(:expected_json) do
+      {
+        type: :object,
+        properties: {
+          name: {
+            type: :string
+          },
+          settings: {
+            type: :object,
+            properties: {
+              email: {
+                type: :string
+              }
+            }
+          },
+          preferences: {
+            anyOf: [
+              {
+                type: :object,
+                properties: {
+                  enabled: {
+                    type: :boolean,
+                    default: true
+                  }
+                }
+              },
+              {
+                type: :null
+              }
+            ]
+          },
+          ids: {
+            type: :array,
+            items: {
+              anyOf: [
+                {type: :number},
+                {type: :string}
+              ]
+            }
+          }
+        }
+      }
+    end
+  end
+end

--- a/spec/integration/builder_reopening_spec.rb
+++ b/spec/integration/builder_reopening_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+RSpec.describe Examples::BuilderReopening, type: :integration do
+  it_behaves_like 'a builder' do
+    let(:expected_json) do
+      {
+        type: :object,
+        properties: {
+          name: {
+            type: :string
+          },
+          settings: {
+            type: :object,
+            properties: {
+              email: {
+                type: :string
+              },
+              phone_number: {
+                type: :string
+              }
+            }
+          },
+          preferences: {
+            anyOf: [
+              {
+                type: :object,
+                properties: {
+                  enabled: {
+                    type: :boolean,
+                    default: true
+                  }
+                }
+              },
+              {
+                type: :null
+              }
+            ]
+          },
+          ids: {
+            type: :array,
+            items: {
+              type: :string,
+            }
+          }
+        }
+      }
+    end
+  end
+end

--- a/spec/support/examples/builder_initialization.rb
+++ b/spec/support/examples/builder_initialization.rb
@@ -1,0 +1,41 @@
+module Examples
+  class BuilderInitialization
+    include JSON::SchemaBuilder
+
+    def example
+      obj = object
+      obj.string :name
+      settings_for(obj)
+      preferences_for(obj)
+      add_ids_to(obj)
+      obj
+    end
+
+    def settings_for(obj)
+      settings = obj.object :settings
+      settings.string :email
+      settings
+    end
+
+    def preferences_for(obj)
+      preferences = obj.entity :preferences
+      preferences.any_of preference
+      preferences.any_of null
+    end
+
+    def preference
+      obj = object
+      enabled = obj.boolean :enabled
+      enabled.default = true
+      obj
+    end
+
+    def add_ids_to(obj)
+      ids = obj.array :ids
+      ids.items do
+        any_of number
+        any_of string
+      end
+    end
+  end
+end

--- a/spec/support/examples/builder_reopening.rb
+++ b/spec/support/examples/builder_reopening.rb
@@ -1,0 +1,13 @@
+module Examples
+  class BuilderReopening < BuilderInitialization
+    def example
+      obj = super
+      obj.extend(:settings) do
+        string :phone_number
+      end
+      ids = obj.array :ids
+      ids.items type: :string
+      obj
+    end
+  end
+end


### PR DESCRIPTION
Allows schemas to be built iteratively for #4:

``` ruby
obj = object
obj.string :name
```

Also allows schema entities to reopen and modify children with `extend(name)`:

``` ruby
obj = object do
  object :an_object do
    string :name
  end
end

obj.extend(:an_object) do
  string :another_name
end

# an_object is now {properties: {name: {type: "string"}, another_name: {type: "string"}}}
```

To replace a child entity, just redefine it:

``` ruby
obj = object do
  object :an_object do
    string :name
  end
end

obj.object :an_object do
  string :replacement_name
end

# an_object is now only {properties: {replacement_name: {type: "string"}}}
```