### PR TITLE
9 endless recursion fix

### DIFF
--- a/lib/json/schema_builder/entity.rb
+++ b/lib/json/schema_builder/entity.rb
@@ -149,7 +149,7 @@ module JSON
 
         schema.data.keep_if { |k| k == "anyOf" }
         return any_of_options.unshift(everything_else) unless initial_object
-        initial_object.deep_merge! everything_else.as_json
+        initial_object.deep_merge! everything_else
       end
 
       def any_of_options

--- a/lib/json/schema_builder/entity.rb
+++ b/lib/json/schema_builder/entity.rb
@@ -144,12 +144,13 @@ module JSON
 
       def build_any_of
         initial_object  = any_of_options.find { |opt| opt.as_json['type'] == 'object' }
-        everything_else = schema.data.reject { |k| k == "anyOf" }
+        everything_else = schema.data.except("anyOf")
         return unless everything_else.present?
 
         schema.data.keep_if { |k| k == "anyOf" }
         return any_of_options.unshift(everything_else) unless initial_object
         initial_object.deep_merge! everything_else
+        initial_object['properties'] = children.select { |c| c.name.presence }.map { |c| [c.name, c] }.to_h
       end
 
       def any_of_options

--- a/lib/json/schema_builder/entity.rb
+++ b/lib/json/schema_builder/entity.rb
@@ -139,16 +139,21 @@ module JSON
       end
 
       def extract_types
-        return unless any_of.present?
-        everything_else = schema.data.reject { |k, v| k == "anyOf" }
+        build_any_of if any_of.present?
+      end
+
+      def build_any_of
+        initial_object  = any_of_options.find { |opt| opt.as_json['type'] == 'object' }
+        everything_else = schema.data.reject { |k| k == "anyOf" }
         return unless everything_else.present?
-        schema.data.select! { |k, v| k == "anyOf" }
-        if initial = schema.data['anyOf'].find { |opt| opt.as_json.try(:[], 'type') == 'object' }
-          initial.deep_merge! everything_else.as_json
-        else
-        schema.data["anyOf"].unshift everything_else
-        end
-        schema.data["anyOf"].uniq!
+
+        schema.data.keep_if { |k| k == "anyOf" }
+        return any_of_options.unshift(everything_else) unless initial_object
+        initial_object.deep_merge! everything_else.as_json
+      end
+
+      def any_of_options
+        schema.data["anyOf"]
       end
 
       def initialize_parent_with(opts)

--- a/lib/json/schema_builder/object.rb
+++ b/lib/json/schema_builder/object.rb
@@ -23,6 +23,7 @@ module JSON
             self.properties[child.name] = child.as_json
           end
         end
+        build_any_of if @nullable
       end
 
       def extract_types

--- a/spec/integration/builder_initialization_spec.rb
+++ b/spec/integration/builder_initialization_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe Examples::BuilderInitialization, type: :integration do
               }
             }
           },
+          target: {
+            anyOf: [
+              {
+                type: :object,
+                properties: {
+                  id: {
+                    type: :number
+                  }
+                }
+              },
+              {
+                type: :null
+              }
+            ]
+          },
           preferences: {
             anyOf: [
               {

--- a/spec/integration/builder_reopening_spec.rb
+++ b/spec/integration/builder_reopening_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe Examples::BuilderReopening, type: :integration do
               }
             }
           },
+          target: {
+            anyOf: [
+              {
+                type: :object,
+                properties: {
+                  id: {
+                    type: :number
+                  }
+                }
+              },
+              {
+                type: :null
+              }
+            ]
+          },
           preferences: {
             anyOf: [
               {

--- a/spec/integration/expand_null_spec.rb
+++ b/spec/integration/expand_null_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe Examples::ExpandNullTrue, type: :integration do
+  it_behaves_like 'a builder' do
+    let(:expected_json) do
+      {
+        "type": "object",
+        "required": [
+          "foo"
+        ],
+        "properties": {
+          "foo": {
+            "type": "object",
+            "required": [
+              "bar"
+            ],
+            "properties": {
+              "bar": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "baz": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    end
+  end
+end

--- a/spec/integration/nested_nullable_spec.rb
+++ b/spec/integration/nested_nullable_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe Examples::NestedNullable, type: :integration do
+  it_behaves_like 'a builder' do
+    let(:expected_json) do
+      {
+        type: 'object',
+        properties: {
+          nullable_object: {
+            anyOf: [
+              {
+                type: 'object',
+                properties: {
+                  nullable_string: {
+                    anyOf: [
+                      {
+                        type: 'string'
+                      },
+                      {
+                        type: 'null'
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                type: 'null'
+              }
+            ]
+          }
+        }
+      }
+    end
+  end
+end

--- a/spec/support/examples/builder_initialization.rb
+++ b/spec/support/examples/builder_initialization.rb
@@ -6,9 +6,16 @@ module Examples
       obj = object
       obj.string :name
       settings_for(obj)
+      target_for(obj)
       preferences_for(obj)
       add_ids_to(obj)
       obj
+    end
+
+    def target_for(obj)
+      target = obj.object :target, null: true
+      target.number :id
+      target
     end
 
     def settings_for(obj)

--- a/spec/support/examples/expand_null_true.rb
+++ b/spec/support/examples/expand_null_true.rb
@@ -1,0 +1,13 @@
+module Examples
+  class ExpandNullTrue
+    include JSON::SchemaBuilder
+
+    def example
+      object.tap do |base_obj|
+        foo_obj = base_obj.object(:foo, required: true)
+        bar_obj = foo_obj.object(:bar, null: true, required: true)
+        bar_obj.string :baz
+      end
+    end
+  end
+end

--- a/spec/support/examples/nested_nullable.rb
+++ b/spec/support/examples/nested_nullable.rb
@@ -1,0 +1,12 @@
+module Examples
+  class NestedNullable
+    include JSON::SchemaBuilder
+
+    def example
+      object.tap do |base_obj|
+        obj = base_obj.object :nullable_object, null: true
+        obj.string :nullable_string, null: true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #9 

This fixes the endless recursion happening on extending objects with `null: true`.

The problem was that, when extending, objects get `reinitialize`d. In the `extract_type` they were then further extended using `any_of(null)` which caused an infinite loop.

Another problem was that adding children to nullable entities could lead to the childrens properties getting merged not into the any_of structure, but the root structure, which was not desired. I added a test and and a `build_any_of` call to `Object#initialize_children`.

I've moved the `any_of(null)` call to initialization (the normal one) so that this does not happen. 

I also added a specification of what I think the resulting schema should look like and had to do horrible hacks to get there. I aim to clean those up shortly, thus the. 